### PR TITLE
Support lambdas #17

### DIFF
--- a/src/test/resources/test/mustache-test.js
+++ b/src/test/resources/test/mustache-test.js
@@ -26,3 +26,19 @@ exports.testRender = function () {
 exports.testExamples = function () {
     testInstance.runScript('/lib/examples/mustache/render.js')
 };
+
+
+exports.testLambda = function () {
+    const view = resolve('view/lambda.html');
+    const result = mustache.render(view, {
+            name: "Willy",
+            wrapped() {
+                return function(text, render) {
+                    return "<b>" + render(text) + "</b>"
+                }
+            }
+        }
+    );
+
+    assertHtmlEquals('view/lambda-result.html', result);
+};

--- a/src/test/resources/test/view/lambda-result.html
+++ b/src/test/resources/test/view/lambda-result.html
@@ -1,0 +1,1 @@
+<b>Willy is awesome.</b>

--- a/src/test/resources/test/view/lambda.html
+++ b/src/test/resources/test/view/lambda.html
@@ -1,0 +1,1 @@
+{{#wrapped}}{{name}} is awesome.{{/wrapped}}


### PR DESCRIPTION
JMustache implements lambdas differently by avoiding recompilation. It made implementation not trivial.
I tried to simulate  official syntax, because we use JavaScript object as a model.
Implementation is not optimal, but probably can be improved in future by caching, if needed.

Also, there is a difference how line-wraps are treated in Java implementation lambdas - trailing line-wrap is kept. I didn't do anything about that, because template writers can easily avoid it: `{{#wrapped}}{{name}} is awesome.{{/wrapped}}`
