### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `releaseBranch:` block to `enonic-gradle.yml` listing both `master` and `2.x` so the build-and-publish action recognizes the maintenance branch as a release branch.
- Maintenance-branch state otherwise unchanged: `xpVersion=7.0.0`, `version=2.1.2-SNAPSHOT` preserved.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, future commits on `2.x` produce releases via the build-and-publish action

🤖 Generated with [Claude Code](https://claude.com/claude-code)