### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,13 +13,13 @@ repositories {
 
 dependencies {
     compileOnly xplibs.api.portal
-    implementation 'com.samskivert:jmustache:1.16'
+    implementation libs.jmustache
 
     testImplementation "com.enonic.xp:testing:${xpVersion}"
-    testImplementation platform( 'org.junit:junit-bom:6.0.3' )
-    testImplementation 'org.junit.jupiter:junit-jupiter'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testImplementation 'org.mockito:mockito-core:5+'
+    testImplementation platform( libs.junit.bom )
+    testImplementation libs.junit.jupiter
+    testRuntimeOnly libs.junit.platform.launcher
+    testImplementation libs.mockito.core
 }
 
 test {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,11 @@
+[versions]
+jmustache = "1.16"
+junit = "6.0.3"
+mockito-core = "5+"
+
+[libraries]
+jmustache = { module = "com.samskivert:jmustache", version.ref = "jmustache" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito-core" }


### PR DESCRIPTION
## Summary

Migrates `lib-mustache` from inline dependency version strings to a Gradle TOML version catalog at `gradle/libs.versions.toml`. Pin-for-pin migration — no version bumps.

## Conventions adopted

- Alphabetical sort of `[versions]` and `[libraries]` blocks.
- Lowercase hyphen-separated keys (`mockito-core`, `junit-bom`).
- `xpVersion` left in `gradle.properties` — the rest of the toolchain expects it there.
- `xplibs.*` accessors untouched (those come from the XP gradle plugin, not the project's catalog).
- No `[plugins]` block — plugin versions are already declared inline in `build.gradle` and were out of scope.

## New catalog

```toml
[versions]
jmustache = "1.16"
junit = "6.0.3"
mockito-core = "5+"

[libraries]
jmustache = { module = "com.samskivert:jmustache", version.ref = "jmustache" }
junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito-core" }
```

## Verification

- `./gradlew dependencies` for both `runtimeClasspath` and `testRuntimeClasspath` produces an identical tree to pre-migration HEAD.
- `./gradlew clean build` green locally.

## Test plan

- [x] Dependency tree unchanged (diffed against master)
- [x] `./gradlew clean build` succeeds locally
- [ ] CI build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)