### PR TITLE
Add @enonic-types/lib-mustache types package #51

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -2,6 +2,10 @@ name: Gradle Build
 
 on: [ push ]
 
+permissions:
+  id-token: write  # Required for npm OIDC / trusted publishing
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,6 +17,7 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          npmPublish: true
           releaseBranch: |
             master
             2.x

--- a/build.gradle
+++ b/build.gradle
@@ -25,3 +25,15 @@ dependencies {
 test {
     useJUnitPlatform()
 }
+
+// Assemble the @enonic-types/lib-mustache npm package (published on release by the CI npmPublish step).
+tasks.register('assembleTypes', Copy) {
+    from 'types'
+    into layout.buildDirectory.dir('types')
+    filesMatching('package.json') {
+        filter { line ->
+            line.replaceAll(/"version":\s*"[^"]*"/, "\"version\": \"${project.version}\"")
+        }
+    }
+}
+jar.dependsOn assembleTypes

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,14 @@
+import type { ResourceKey } from "@enonic-types/core";
+
+declare module "/lib/mustache" {
+    /**
+     * Renders a view using Mustache.
+     *
+     * @param view Location of the view. Use `resolve(...)` to resolve a view.
+     * @param model Model that is passed to the view.
+     * @returns The rendered output.
+     */
+    export function render(view: ResourceKey, model: Record<string, unknown>): string;
+}
+
+export {};

--- a/types/package.json
+++ b/types/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@enonic-types/lib-mustache",
+  "version": "0.0.0",
+  "description": "Type definitions for the Enonic XP Mustache library",
+  "types": "index.d.ts",
+  "files": [
+    "*"
+  ],
+  "keywords": [
+    "enonic",
+    "enonic-xp",
+    "lib-mustache",
+    "mustache",
+    "types",
+    "typescript"
+  ],
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/enonic/lib-mustache#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/enonic/lib-mustache.git"
+  },
+  "bugs": {
+    "url": "https://github.com/enonic/lib-mustache/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@enonic-types/core": "^8.0.0"
+  }
+}


### PR DESCRIPTION
Publishes a TypeScript types package for lib-mustache so consumers stop hand-maintaining local `/lib/mustache` declarations (e.g. app-features currently ships its own copy).

## Changes
- `types/index.d.ts` — ambient module declaration for `/lib/mustache` (`render(view, model)`), seeded from the proven declaration in app-features.
- `types/package.json` — `@enonic-types/lib-mustache` manifest (version substituted at build time).
- `build.gradle` — `assembleTypes` Copy task builds `build/types` with `project.version` injected; `jar.dependsOn assembleTypes` (mirrors app-guillotine's pattern; no node build needed for a pure-JS lib).
- `enonic-gradle.yml` — `npmPublish: true` on build-and-publish + `id-token: write` for OIDC trusted publishing.

Verified locally: `./gradlew build` green; `build/types` contains `index.d.ts` + `package.json` with the substituted version.

**Note:** the first publish of a brand-new `@enonic-types/lib-mustache` needs the npm trusted-publisher / package access configured org-side. Depends on enonic/release-tools#71 (publish-only npmPublish) — merged.

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)