### PR TITLE
Align docs to standard layout #67

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "3.x"
       - "2.x"
     paths:
       - 'docs/**'

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,15 +1,20 @@
 = Mustache library
+:toc: right
 
-image::https://img.shields.io/badge/xp-7.+-blue.svg[role="right"]
+== Introduction
+
+NOTE: Versions 3.x target XP 8+.
 
 Mustache library allows you to render templates using the http://mustache.github.io/[Mustache templating language]!
+
+== Installation
 
 To start using this library, add the following into your `build.gradle` file:
 
 [source,groovy]
 ----
 dependencies {
-  include 'com.enonic.lib:lib-mustache:2.0.0'
+  include "com.enonic.lib:lib-mustache:${libVersion}"
 }
 ----
 
@@ -94,7 +99,7 @@ Output:
 
 == API
 
-The following function is  defined in this library.
+The following function is defined in this library.
 
 === `render`
 

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -2,12 +2,12 @@
   "versions": [
     {
       "label": "stable",
-      "checkout": "2.x",
+      "checkout": "3.x",
       "latest": true
     },
     {
-      "label": "next",
-      "checkout": "master"
+      "label": "2.x",
+      "checkout": "2.x"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Aligns `docs/index.adoc` to the reference layout used by `enonic/lib-cors`: `:toc: right`, `== Introduction` with a `NOTE: Versions 3.x target XP 8+.`, and `== Installation` section.
- Drops the outdated `xp-7.+` badge; the 3.x line targets XP 8+.
- Replaces hard-coded `com.enonic.lib:lib-mustache:2.0.0` with `${libVersion}` in the install snippet — no more stale version reference.
- Updates `docs/versions.json`: `stable` → `3.x` (latest), `2.x` kept as an alternate. Master no longer publishes as a labelled version.
- Adds `3.x` to `.github/workflows/enonic-docgen.yml` push triggers so all three versioned branches (`master`, `3.x`, `2.x`) trigger docgen.

## Notes
- Docs on this branch (master) are minimal — a single `render` function. No inline `(added in vX.Y)` / "Starting from version X …" annotations to strip. The only historical clutter was the XP 7 badge and the hard-coded 2.0.0 install version, both handled here.
- The `2.x` branch is deliberately untouched.
- A follow-up PR against `3.x` will cherry-pick just the doc content changes so published stable docs reflect the same current framing.

Closes #67

## Test plan
- [x] `docs/versions.json` is valid JSON
- [x] `.github/workflows/enonic-docgen.yml` is valid YAML
- [ ] docgen workflow succeeds on merge to master (external, runs post-merge)